### PR TITLE
ci: Publishing application as self-contained executable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,22 +12,22 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4.1.1
-    
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4.0.0
       with:
         dotnet-version: 8.x
-        
+
     - name: Restore dependencies
       run: dotnet restore
-      
+
     - name: Build
       run: dotnet build
-      
+
     - name: Publish
       run: dotnet publish -c Release
       working-directory: ./SubRenamer
-      
+
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v4.0.0
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - "v*.*.*"
-      
+
 jobs:
   build:
     runs-on: windows-latest
@@ -12,38 +12,38 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4.1.1
-    
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4.0.0
       with:
         dotnet-version: 8.x
-        
+
     - name: Restore dependencies
       run: dotnet restore
-      
+
     - name: Build
       run: dotnet build
-      
+
     - name: Publish
       run: dotnet publish -r win-x64 -p:PublishSingleFile=true -c Release --self-contained false
       working-directory: ./SubRenamer
-      
+
     - name: Publish
       run: dotnet publish -r win-arm64 -p:PublishSingleFile=true -c Release --self-contained false
       working-directory: ./SubRenamer
-      
+
     - name: Zip Build Artifact
       uses: vimtor/action-zip@v1
       with:
         files: ./SubRenamer/bin/Release/net8.0-windows/win-x64/publish
         dest: SubRenamer-win-x64.zip
-      
+
     - name: Zip Build Artifact
       uses: vimtor/action-zip@v1
       with:
         files: ./SubRenamer/bin/Release/net8.0-windows/win-arm64/publish
         dest: SubRenamer-win-arm64.zip
-      
+
     - name: Release
       uses: softprops/action-gh-release@v1
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,30 +25,26 @@ jobs:
       run: dotnet build
 
     - name: Publish
-      run: dotnet publish -r win-x64 -p:PublishSingleFile=true -c Release --self-contained false
+      run: |
+        dotnet publish -c Release -r win-x64 -p:PublishSingleFile=true -p:PublishDir=.\artifacts\win-x64-with-runtime --self-contained true
+        dotnet publish -c Release -r win-arm64 -p:PublishSingleFile=true -p:PublishDir=.\artifacts\win-arm64-with-runtime --self-contained true
+        dotnet publish -c Release -r win-x64 -p:PublishSingleFile=true -p:PublishDir=.\artifacts\win-x64 --self-contained false
+        dotnet publish -c Release -r win-arm64 -p:PublishSingleFile=true -p:PublishDir=.\artifacts\win-arm64 --self-contained false
       working-directory: ./SubRenamer
 
-    - name: Publish
-      run: dotnet publish -r win-arm64 -p:PublishSingleFile=true -c Release --self-contained false
-      working-directory: ./SubRenamer
-
-    - name: Zip Build Artifact
-      uses: vimtor/action-zip@v1
-      with:
-        files: ./SubRenamer/bin/Release/net8.0-windows/win-x64/publish
-        dest: SubRenamer-win-x64.zip
-
-    - name: Zip Build Artifact
-      uses: vimtor/action-zip@v1
-      with:
-        files: ./SubRenamer/bin/Release/net8.0-windows/win-arm64/publish
-        dest: SubRenamer-win-arm64.zip
+    - name: Compress Build Artifact
+      run: |
+        Compress-Archive -Path .\SubRenamer\artifacts\win-x64-with-runtime\* -DestinationPath .\SubRenamer-with-runtime-win-x64.zip
+        Compress-Archive -Path .\SubRenamer\artifacts\win-arm64-with-runtime\* -DestinationPath .\SubRenamer-with-runtime-win-arm64.zip
+        Compress-Archive -Path .\SubRenamer\artifacts\win-x64\* -DestinationPath .\SubRenamer-win-x64.zip
+        Compress-Archive -Path .\SubRenamer\artifacts\win-arm64\* -DestinationPath .\SubRenamer-win-arm64.zip
+        Get-FileHash -Path .\SubRenamer*.zip | Format-List > sha256sum.txt
 
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
         files: |
-          SubRenamer-win-x64.zip
-          SubRenamer-win-arm64.zip
+          SubRenamer*.zip
+          sha256sum.txt
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## This PR introduce build-related changes
- [x] Publishing application as self-contained executable. Users of the application can run it on a machine that doesn't have the .NET runtime installed.

- [x] Use native PowerShell command to compress artifact. Clear ![warning](https://github.com/arition/SubRenamer/actions/runs/7161440746).

- [x] Use native PowerShell command to generate sha256sum file. For users to verify the integrity of downloaded files.

- [x] Trim trailing whitespace.

## Additional information
- [x] All CI tests are passing: https://github.com/startgenshin/SubRenamer/actions
- [x] Release assets are passing: https://github.com/startgenshin/SubRenamer/releases